### PR TITLE
feat: update cbl-reactnative to 0.6.1 from npm

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost (1.84.0)
-  - cbl-reactnative (0.2.0):
-    - CouchbaseLite-Swift-Enterprise (~> 3.1)
+  - cbl-reactnative (0.6.1):
+    - CouchbaseLite-Swift-Enterprise (= 3.2.1)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -22,7 +22,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - CouchbaseLite-Swift-Enterprise (3.1.7)
+  - CouchbaseLite-Swift-Enterprise (3.2.1)
   - DoubleConversion (1.1.6)
   - EXConstants (16.0.2):
     - ExpoModulesCore
@@ -2177,93 +2177,93 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
-  cbl-reactnative: ab9c9f8558b3298c10bf684cabb81418973337f2
-  CouchbaseLite-Swift-Enterprise: 7fe8b730168a14ec96adcefb89a0109a4ee5b9f0
+  cbl-reactnative: bcdff9de41ee3c3d6c005d79435c395e76c903ca
+  CouchbaseLite-Swift-Enterprise: 6a1eddeed0b450d00d2336bcf60c9a71e228f0e4
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EXConstants: 409690fbfd5afea964e5e9d6c4eb2c2b59222c59
+  EXConstants: 89d35611505a8ce02550e64e43cd05565da35f9a
   EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
-  EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  Expo: 33132a667698a3259a4e6c0af1b4936388e5fa33
-  expo-dev-client: 4f9100af6be210a360aa67f42649881251aa362a
-  expo-dev-launcher: fc33891203a796c1e9cf0507d54707bf75a8b7de
-  expo-dev-menu: d93c46bfa7bd088b20423945b6d0fb3dff7d647b
-  expo-dev-menu-interface: be32c09f1e03833050f0ee290dcc86b3ad0e73e4
-  ExpoAsset: 323700f291684f110fb55f0d4022a3362ea9f875
-  ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
-  ExpoFont: 00756e6c796d8f7ee8d211e29c8b619e75cbf238
-  ExpoHead: fcb28a68ed4ba28f177394d2dfb8a0a8824cd103
-  ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
-  ExpoModulesCore: 0f12e4d48d4484886e2940ece708f4dc73d6319c
-  ExpoSystemUI: d4f065a016cae6721b324eb659cdee4d4cf0cb26
-  ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
-  EXSplashScreen: 5461621eafa685600296f3702ed35cc8dcb18aae
-  EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
+  EXManifests: ebb7f551c340c0d06f3ecd9ae662e418bf68417c
+  Expo: 360cbad5d96001c23738d6c5a0db835008ccd8a2
+  expo-dev-client: 72c9a99c9a600403d7f5fa54205e61f5f237d0ee
+  expo-dev-launcher: 6bcecb898974f6602f4b06dbc0e146f00f02c601
+  expo-dev-menu: 8e221dd2c732bf8ef0e67f0476ce92f5e79fe5a1
+  expo-dev-menu-interface: 540a154388e6ae7027b406827737e82b0d25da27
+  ExpoAsset: 286fee7ba711ce66bf20b315e68106b13b8629fc
+  ExpoFileSystem: 2988caaf68b7cb706e36d382829d99811d9d76a5
+  ExpoFont: 38dddf823e32740c2a9f37c926a33aeca736b5c4
+  ExpoHead: 37970100b038694465cc39044cf23f3d1f56fade
+  ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
+  ExpoModulesCore: 6c2ed6e5504d0281a6e2d3ece422202639074f99
+  ExpoSystemUI: 2072307375696c398a5d75633bdd5143fadc3d26
+  ExpoWebBrowser: cf10afe886891ab495877dada977fe6c269614a4
+  EXSplashScreen: 70d83a91edbf776efb27e329ea72b0c432e001d8
+  EXUpdatesInterface: c3a9494c2173db6442c7d5ad4e5b984972760fd3
   FBLazyVector: 38bb611218305c3bc61803e287b8a81c6f63b619
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 3b6e0717ca847e2fc90a201e59db36caf04dee88
-  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
+  RCT-Folly: 34124ae2e667a0e5f0ea378db071d27548124321
   RCTDeprecation: 34cbf122b623037ea9facad2e92e53434c5c7422
   RCTRequired: 24c446d7bcd0f517d516b6265d8df04dc3eb1219
   RCTTypeSafety: ef5e91bd791abd3a99b2c75fd565791102a66352
   React: 643f06bc294806d2db2526b424fdf759e107f514
   React-callinvoker: 34d1fa0c340104f324e2521f546196beb44dfad2
-  React-Core: facd883836d8d1cc1949d2053c58eab5fb22eb75
-  React-CoreModules: f92a2cb11d22f6066823ca547c61e900325dfe44
-  React-cxxreact: f5595a4cbfe5a4e9d401dffa2c1c78bbbbbe75e4
+  React-Core: 14bffba7f3ab7ff5360636854f76af73d7508f00
+  React-CoreModules: f7ab1179f615f46a89d81955828f139888c37504
+  React-cxxreact: 183ff8146b58c9e60bf31857327222f4b233f447
   React-debug: 4a91c177b5b2efcc546fb50bc2f676f3f589efab
-  React-defaultsnativemodule: bb94c3db425b01c760f41a253de8536b3f5497f0
-  React-domnativemodule: 6c581fd39812cafb024171e091c00905b2c3a3e2
-  React-Fabric: a33cc1fdc62a3085774783bb30970531589d2028
-  React-FabricComponents: 98de5f94cbd35d407f4fc78855298b562d8289cb
-  React-FabricImage: 0ce8fd83844d9edef5825116d38f0e208b9ad786
+  React-defaultsnativemodule: 767201fdec92b9647e17d82b76fae2bd59cdb777
+  React-domnativemodule: 4f8e282ba9fa9f537bfa7cb7132268ad116aee4d
+  React-Fabric: a01235a3e8efca6cad64f2773de30620916b94ed
+  React-FabricComponents: da662de0c925a714e377078d15799238f02ece3a
+  React-FabricImage: aadd8130a9563554ff11200593f1fa59ede5c032
   React-featureflags: 37a78859ad71db758e2efdcbdb7384afefa8701e
-  React-featureflagsnativemodule: 52b46e161a151b4653cf1762285e8e899d534e3f
-  React-graphics: c16f1bab97a5d473831a79360d84300e93a614e5
-  React-hermes: 7801f8c0e12f326524b461dc368d3e74f3d2a385
-  React-idlecallbacksnativemodule: 58de2ac968ee80947d19dc8fe20def607e5c2de8
-  React-ImageManager: 98a1e5b0b05528dde47ebcd953d916ac66d46c09
-  React-jserrorhandler: 08f1c3465a71a6549c27ad82809ce145ad52d4f1
-  React-jsi: 161428ab2c706d5fcd9878d260ff1513fdb356ab
-  React-jsiexecutor: abfdc7526151c6755f836235bbaa53b267a0803c
-  React-jsinspector: f0786053a1a258a4d8dde859d1a820c26ee686f0
-  React-jsitracing: 52b849a77d02e2dc262a3031454c23be8dabb4d9
-  React-logger: 8db32983d75dc2ad54f278f344ccb9b256e694fc
-  React-Mapbuffer: 1c08607305558666fd16678b85ef135e455d5c96
-  React-microtasksnativemodule: 87b8de96f937faefece8afd2cb3a518321b2ef99
-  react-native-safe-area-context: a240ad4b683349e48b1d51fed1611138d1bdad97
+  React-featureflagsnativemodule: c184c1e25f0c3b19a9ae2beda2417d26b25b0655
+  React-graphics: 8629b5a56829ffd732114d531181587c9febc38b
+  React-hermes: c06b1e3320ba48c19486560f166af256b14f693c
+  React-idlecallbacksnativemodule: ee7d945ceb2a5b947bbcb447eafdbc9997cf6a0f
+  React-ImageManager: 8f3f1e37eb40c6d629e7b20d4c099a0f7f8d9c89
+  React-jserrorhandler: 78a484802060c7ced1c7ac6142adbb34b1aa3070
+  React-jsi: 03ee4a14742b67b73f4ee60b463541918bca085f
+  React-jsiexecutor: 1e7469147772b1c3334e697c0b578cc9552eed64
+  React-jsinspector: 0380a132ccd34611f0b56169af849b19c4a0f12e
+  React-jsitracing: a9d90572f615d78f661f73ce9b7fb165b12f982b
+  React-logger: 62e11ad27cfcff0fcbfc5df93094f138ad5dd7fe
+  React-Mapbuffer: 4a9b9131acbd8326b1f0e768d0ad63d981a4a92f
+  React-microtasksnativemodule: 8b2d1ac72763e0f7aa2d1dcbe26ea84124948ec8
+  react-native-safe-area-context: df9763c5de6fa38883028e243a0b60123acb8858
   React-nativeconfig: 57781b79e11d5af7573e6f77cbf1143b71802a6d
-  React-NativeModulesApple: 7ff2e2cfb2e5fa5bdedcecf28ce37e696c6ef1e1
+  React-NativeModulesApple: 77edd58a435c1ba641506ba853bd0d594e1f85de
   React-perflogger: 8a360ccf603de6ddbe9ff8f54383146d26e6c936
-  React-performancetimeline: 3cfec915adcb3653a5a633b41e711903844c35d8
+  React-performancetimeline: cb79124751b0ab0f1e5fbd5a4ab6d4cf5f1ef0e9
   React-RCTActionSheet: 1c0e26a88eec41215089cf4436e38188cfe9f01a
-  React-RCTAnimation: d87207841b1e2ae1389e684262ea8c73c887cb04
-  React-RCTAppDelegate: 4ec7824c0cc9cc4b146ca8ee0fd81b10c316a440
-  React-RCTBlob: 79b42cb7db55f34079297687a480dbcf37f023f6
-  React-RCTFabric: 1dd1661db93716f8cb116e451bd9c211a8d15716
-  React-RCTImage: 0c10a75de59f7384a2a55545d5f36fe783e6ecda
-  React-RCTLinking: bf08f4f655bf777af292b8d97449072c8bb196ca
-  React-RCTNetwork: 1b690846b40fc5685af58e088720657db6814637
-  React-RCTSettings: 097e420926dd44153fb25174835b572aded224d6
-  React-RCTText: d8fe2ae9f95b2ccd03b2f534286e938254791992
-  React-RCTVibration: 976466dba32c0981a836e45ce38bcd4c8d6d924e
+  React-RCTAnimation: 6f9c39d1fa9bb0dc3d906c7054466ceb0e773f39
+  React-RCTAppDelegate: a745afb151ad8e8afb1b98eb177fd43d9b8cc009
+  React-RCTBlob: 8135ab1fccd8ab08b0bedbee947eeafe5e3cb3c2
+  React-RCTFabric: 54ecf6a7bc79bd778a7b52bb6e2ea6e9bcbdf539
+  React-RCTImage: 57549e2ed9f9937de393bbdbd36f3f1fba72b247
+  React-RCTLinking: 0cad37249277ff873b6cf0bc699c8d0d9d596347
+  React-RCTNetwork: 1bf1a288cf83be92d9bae971ef059046e22ff801
+  React-RCTSettings: 105953080f8c0350d79557c61c6180b5f15c974f
+  React-RCTText: 6828703d3638ff371ee055618dc540298ed7e7da
+  React-RCTVibration: 201c9f5e4ce7f2980757f4b49366d641a67ca2aa
   React-rendererconsistency: ee0d6f1b4420e1ad5bb01c02170e7ecbd278e307
-  React-rendererdebug: 7fbf02f30d1e0bb0d96d65cf2548219cb53b29b6
+  React-rendererdebug: 01d6526386b22e5cf5c7cbcb3984c2e7f21a624a
   React-rncore: 7ffc5be03adbf0a5cbf1b654483f487a899cff08
-  React-RuntimeApple: e623f002e1871de30a443291171d3f2fb134a6ec
-  React-RuntimeCore: a67357d4f073b1dbe6fbefc5273072027f201e1c
+  React-RuntimeApple: 7fffb421ae456d04f776503ec55614d17a19312d
+  React-RuntimeCore: addfb9c3dc64076a3e9f0935f6aa08679b17beae
   React-runtimeexecutor: 5bb52479abf8081086afb0397dc33dc97202a439
-  React-RuntimeHermes: 860cf64708a12a2fa62366fe51fe000121fa031b
-  React-runtimescheduler: fff88d51ad2c8815fc75930dbac224d680593e6b
-  React-utils: 81a715d9c0a2a49047e77a86f3a2247408540deb
-  ReactCodegen: 60973d382704c793c605b9be0fc7f31cb279442f
-  ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
-  RNGestureHandler: 3b6fa2bfa341c413d3d08444b838515b58e48ee7
-  RNReanimated: b0912c8ba12f6c03db07c851c4de71c3eed6c83c
-  RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
+  React-RuntimeHermes: 7c20e51b6ec8f9be865c2bb547c04e2f18d286cc
+  React-runtimescheduler: 4b04a007fa1aac3fdbbaa7b166d32b4444bcc296
+  React-utils: 2e17380f9c456ac8bf2e63586e18b79f27386edc
+  ReactCodegen: ec0b6ef4308774578943faf102b865b603e3e0f7
+  ReactCommon: c254c0204d81fb3cd63fefd0df97fb8b3d1f63ab
+  RNGestureHandler: 07e93368586098f494729fbda828e8af74855c15
+  RNReanimated: ceca32884756a34f3a3b0ffd12f060a3f44c31fa
+  RNScreens: 28fbd73104cc9719371da9d9aaa3c70d876a8c6b
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: a1d7895431387402a674fd0d1c04ec85e87909b8
 
-PODFILE CHECKSUM: db267eaf90372ab6f307dc04723e71290b5f2049
+PODFILE CHECKSUM: 935980f2db21a23d3975ff7aeaa1971af1b391fd
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@react-navigation/native": "^6.0.2",
         "@rneui/base": "^4.0.0-rc.7",
         "@rneui/themed": "^4.0.0-rc.8",
-        "cbl-reactnative": "file:cbl-reactnative-0.2.0.tgz",
+        "cbl-reactnative": "0.6.1",
         "expo": "~51.0.32",
         "expo-constants": "~16.0.2",
         "expo-dev-client": "~4.0.26",
@@ -7985,9 +7985,9 @@
       ]
     },
     "node_modules/cbl-reactnative": {
-      "version": "0.2.0",
-      "resolved": "file:cbl-reactnative-0.2.0.tgz",
-      "integrity": "sha512-ZbdQxgXslH2KXBg/45atjvwHj9GY/BAR+AOcwBTjC3eaOhjd7MIRLmuiOeeQqsTPSgqwk+FLex+EJ7zAAAmQHA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cbl-reactnative/-/cbl-reactnative-0.6.1.tgz",
+      "integrity": "sha512-+rd5MEIrUPtlJlpCuMFa9GPJP+eBKk6ymME5xTklaV5kmAl/MRCphYlOR1KzfL3j4scztoOVEpH6J8/YcUmNkw==",
       "license": "Apache-2.0",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/native": "^6.0.2",
     "@rneui/base": "^4.0.0-rc.7",
     "@rneui/themed": "^4.0.0-rc.8",
-    "cbl-reactnative": "0.2.0",
+    "cbl-reactnative": "0.6.1",
     "expo": "~51.0.32",
     "expo-constants": "~16.0.2",
     "expo-dev-client": "~4.0.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,10 +3349,10 @@ caniuse-lite@^1.0.30001646:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz"
   integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
 
-"cbl-reactnative@file:cbl-reactnative-0.2.0.tgz":
-  version "0.2.0"
-  resolved "file:cbl-reactnative-0.2.0.tgz"
-  integrity sha512-ZbdQxgXslH2KXBg/45atjvwHj9GY/BAR+AOcwBTjC3eaOhjd7MIRLmuiOeeQqsTPSgqwk+FLex+EJ7zAAAmQHA==
+cbl-reactnative@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/cbl-reactnative/-/cbl-reactnative-0.6.1.tgz"
+  integrity sha512-+rd5MEIrUPtlJlpCuMFa9GPJP+eBKk6ymME5xTklaV5kmAl/MRCphYlOR1KzfL3j4scztoOVEpH6J8/YcUmNkw==
   dependencies:
     react-native-uuid "^2.0.2"
 


### PR DESCRIPTION
This PR updates the cbl-reactnative package to 0.6.1 and uses the npm registry instead of a local file.

The apps are running fine:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/a83f4bcd-2188-4982-8736-02a735cd5aac" />

<img width="352" alt="image" src="https://github.com/user-attachments/assets/b651f3d6-22bf-4cde-ad6d-ae973484975b" />
